### PR TITLE
Feature/style tag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,22 @@ h2 {
 
 On the contrary, **Webfont-DL plugin** does most of the job at build time, leaves the minimum to the browser.
 
-**Webfont-DL plugin** downloads the Google Fonts CSS file(s), extracts the font URLs, downloads the fonts, generates a webfont CSS file, add them to the bundle and injects the following code into your website's `<head>` using a non-render blocking method <i>(example)</i>:
+**Webfont-DL plugin** downloads the Google Fonts CSS file(s), extracts the font URLs, downloads the fonts, generates an inline style tag **or** a webfont CSS file, add them to the bundle and injects the following code into your website's `<head>` using a non-render blocking method <i>(example)</i>:
+
+```html
+<style>
+	@font-face {
+		font-family: 'Fira Code';
+		font-style: normal;
+		font-weight: 300;
+		font-display: swap;
+		src: url(/assets/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_GNsJV37Nv7g.9c348768.woff2) format('woff2');
+		unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+	}
+	...
+</style>
+```
+**or**
 
 ```html
 <link rel="preload" as="style" href="/assets/webfonts.b904bd45.css">
@@ -138,6 +153,11 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 ```
 
 📱 What happens on client-side with **Webfont-DL plugin**:
+
+1. Load fonts from the `inline style tag`.
+
+**or**
+
 1. First line instructs the browser to prefetch a CSS file for later use as stylesheet. [**`preload`**]
 1. Second line instructs the browser to load and use that CSS file as a "`print`" stylesheet <i>(non-render blocking)</i>. After loading it promote to "`all`" media type stylesheet (by removing the "`media`" attribute). [**`stylesheet`**]
 

--- a/readme.md
+++ b/readme.md
@@ -144,14 +144,15 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 <br>
 
 ### 🛠️ **Options**
-```ts
+```js
 ViteWebfontDownload(
- [
-  'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
- ],
- {
-  async: false
- }
+  [
+    'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
+  ],
+  {
+	injectAsStyleTag: true,
+    async: true
+  }
 )
 ```
 
@@ -159,13 +160,16 @@ ViteWebfontDownload(
 
 ```js
 ViteWebfontDownload(
- {
-  async: false
- }
+  [],
+  {
+	injectAsStyleTag: true,
+    async: true
+  }
 )
 ```
 
-**`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues
+**`injectAsStyleTag`**: inject webfonts as `<style>` tag or as an external `.css` file
+**`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues (has no effect when `injectAsStyleTag` is `true`)
 
 ## 📚 Resources
 * [Page Speed Checklist / Fix & Eliminate Render Blocking Resources](https://pagespeedchecklist.com/eliminate-render-blocking-resources)

--- a/src/css-injector.ts
+++ b/src/css-injector.ts
@@ -2,14 +2,21 @@ import { Options } from './types';
 
 export class CssInjector {
 
-	constructor(private options: Options) {}
+	constructor(private options: Options) { }
 
-	public inject(html: string, base: string, path: string): string {
+	public injectAsStylesheet(html: string, base: string, path: string): string {
 		if (this.options.async) {
 			return this.injectAsync(html, base, path);
 		} else {
 			return this.injectSync(html, base, path);
 		}
+	}
+
+	public injectAsStyleTag(html: string, cssContent: string): string {
+		return html.replace(
+			/([ \t]*)<\/head>/,
+			`$1<style>${cssContent}</style>\n</head>`
+		);
 	}
 
 

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -1,7 +1,7 @@
 import type { Options } from './types';
 
 const defaultOptions: Options = {
-	injectToHead: true,
+	injectAsStyleTag: true,
 	async: true,
 }
 

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -1,6 +1,7 @@
 import type { Options } from './types';
 
 const defaultOptions: Options = {
+	injectToHead: true,
 	async: true,
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export function ViteWebfontDownload(
 		_webfontUrls = [];
 	}
 
-	if (typeof _webfontUrls === 'string') {
+	if (typeof _webfontUrls === 'string' && _webfontUrls !== '') {
 		_webfontUrls = [_webfontUrls];
 	}
 
@@ -95,7 +95,7 @@ export function ViteWebfontDownload(
 	};
 
 	const injectToHtml = (html: string, cssContent: string, base: string, cssPath: string): string => {
-		if (options.injectToHead === false) {
+		if (options.injectAsStyleTag === false) {
 			return cssInjector.injectAsStylesheet(html, base, cssPath);
 		}
 
@@ -188,7 +188,7 @@ export function ViteWebfontDownload(
 				await downloadFonts();
 				replaceFontUrls();
 
-				if (options.injectToHead === false) {
+				if (options.injectAsStyleTag === false) {
 					saveCss();
 				}
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ServerResponse } from 'http';
-import type { ViteDevServer, Connect, ResolvedConfig, Plugin, HtmlTagDescriptor } from 'vite';
+import type { ViteDevServer, Connect, ResolvedConfig, Plugin } from 'vite';
 import { PluginContext } from 'rollup';
 import type { Font, Options } from './types';
 import { CssLoader } from './css-loader';
@@ -184,19 +184,14 @@ export function ViteWebfontDownload(
 				}
 			}
 
-			if (options?.injectToHead) {
-				const tag: HtmlTagDescriptor[] = [
-					{
-						tag: 'style',
-						children: cssContent,
-					}
-				]
+			html = indexHtmlProcessor.removeTags(html);
 
-				return tag;
+			if (options?.injectToHead) {
+				html = cssInjector.injectAsStyleTag(html, cssContent);
+			} else {
+				html = cssInjector.injectAsStylesheet(html, base, cssPath);
 			}
 
-			html = indexHtmlProcessor.removeTags(html);
-			html = cssInjector.inject(html, base, cssPath);
 
 			return html;
 		},

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,13 +7,13 @@ export interface Font {
  * This is the description of the interface
  *
  * @interface Options
- * @member {boolean} async is used to import stylesheet asynchronously.
  * @member {boolean} injectToHead is used to inject critical css between style tag.
+ * @member {boolean} async is used to import stylesheet asynchronously.
  */
 export interface Options {
-	/** Import stylesheet asynchronously. Has no effect when ```injectToHead``` is true */
-	async?: boolean;
 	/** Inject critical css between style tag */
 	injectToHead?: boolean;
+	/** Import stylesheet asynchronously. Has no effect when `injectToHead` is true */
+	async?: boolean;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,7 +3,15 @@ export interface Font {
 	localPath: string;
 }
 
+/**
+ * This is the description of the interface
+ *
+ * @interface Options
+ * @member {boolean} injectToHead is used to inject critical css between style tag
+ */
 export interface Options {
 	async?: boolean;
+	/** Inject critical css between style tag */
+	injectToHead?: boolean;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,9 +7,11 @@ export interface Font {
  * This is the description of the interface
  *
  * @interface Options
- * @member {boolean} injectToHead is used to inject critical css between style tag
+ * @member {boolean} async is used to import stylesheet asynchronously.
+ * @member {boolean} injectToHead is used to inject critical css between style tag.
  */
 export interface Options {
+	/** Import stylesheet asynchronously. Has no effect when ```injectToHead``` is true */
 	async?: boolean;
 	/** Inject critical css between style tag */
 	injectToHead?: boolean;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,13 +7,13 @@ export interface Font {
  * This is the description of the interface
  *
  * @interface Options
- * @member {boolean} injectToHead is used to inject critical css between style tag.
+ * @member {boolean} injectAsStyleTag is used to inject critical css between style tag.
  * @member {boolean} async is used to import stylesheet asynchronously.
  */
 export interface Options {
 	/** Inject critical css between style tag */
-	injectToHead?: boolean;
-	/** Import stylesheet asynchronously. Has no effect when `injectToHead` is true */
+	injectAsStyleTag?: boolean;
+	/** Import stylesheet asynchronously. Has no effect when `injectAsStyleTag` is `true` */
 	async?: boolean;
 }
 


### PR DESCRIPTION
- Inject generated css between a `<style>` tag in the `<head>` instead of generating into a separated css file. This approach is not count as render-blocking resource so it's as fast as the async version. This method also fix SSR manifest issue (https://github.com/feat-agency/vite-plugin-webfont-dl/issues/9).
- This will be the default option but you can turn it off if you want use the async method instead:
```js
ViteWebfontDownload([],
 {
  injectAsStyleTag: false
 }
)
```