### PR TITLE
Inject as style tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-webfont-dl",
-	"version": "2.2.1",
+	"version": "3.0.0",
 	"description": "Vite plugin for downloading and injecting webfonts",
 	"keywords": [
 		"vite",

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,22 @@ h2 {
 
 On the contrary, **Webfont-DL plugin** does most of the job at build time, leaves the minimum to the browser.
 
-**Webfont-DL plugin** downloads the Google Fonts CSS file(s), extracts the font URLs, downloads the fonts, generates a webfont CSS file, add them to the bundle and injects the following code into your website's `<head>` using a non-render blocking method <i>(example)</i>:
+**Webfont-DL plugin** downloads the Google Fonts CSS file(s), extracts the font URLs, downloads the fonts, generates an inline style tag **or** a webfont CSS file, add them to the bundle and injects the following code into your website's `<head>` using a non-render blocking method <i>(example)</i>:
+
+```html
+<style>
+	@font-face {
+		font-family: 'Fira Code';
+		font-style: normal;
+		font-weight: 300;
+		font-display: swap;
+		src: url(/assets/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_GNsJV37Nv7g.9c348768.woff2) format('woff2');
+		unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+	}
+	...
+</style>
+```
+**or**
 
 ```html
 <link rel="preload" as="style" href="/assets/webfonts.b904bd45.css">
@@ -138,6 +153,11 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 ```
 
 📱 What happens on client-side with **Webfont-DL plugin**:
+
+1. Load fonts from the `inline style tag`.
+
+**or**
+
 1. First line instructs the browser to prefetch a CSS file for later use as stylesheet. [**`preload`**]
 1. Second line instructs the browser to load and use that CSS file as a "`print`" stylesheet <i>(non-render blocking)</i>. After loading it promote to "`all`" media type stylesheet (by removing the "`media`" attribute). [**`stylesheet`**]
 

--- a/readme.md
+++ b/readme.md
@@ -88,16 +88,6 @@ h2 {
 
 <br>
 
-## 📈 Benchmark
-[Starter Vite project](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-vanilla) with
-
-| [▶️ Standard **Google Fonts**](https://pagespeed.web.dev/report?url=https%3A%2F%2Fwebfont.feat.agency%2F) | 🆚 | [▶️ **Webfont DL** Vite plugin](https://pagespeed.web.dev/report?url=https%3A%2F%2Fwebfont-dl.feat.agency%2F) |
-|:---:|:---:|:---:|
-| [🔗 webfont.feat.agency](https://webfont.feat.agency) | | [🔗 webfont-dl.feat.agency](https://webfont-dl.feat.agency) |
-
-![Compare](./img/compare.png)
-
-
 ## 🔮 How it works
 
 ### **Google Fonts** 📉
@@ -187,6 +177,17 @@ ViteWebfontDownload(
   }
 )
 ```
+
+<br>
+
+## 📈 Benchmark
+[Starter Vite project](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-vanilla) with
+
+| [▶️ Standard **Google Fonts**](https://pagespeed.web.dev/report?url=https%3A%2F%2Fwebfont.feat.agency%2F) | 🆚 | [▶️ **Webfont DL** Vite plugin](https://pagespeed.web.dev/report?url=https%3A%2F%2Fwebfont-dl.feat.agency%2F) |
+|:---:|:---:|:---:|
+| [🔗 webfont.feat.agency](https://webfont.feat.agency) | | [🔗 webfont-dl.feat.agency](https://webfont-dl.feat.agency) |
+
+![Compare](./img/compare.png)
 
 <br>
 

--- a/readme.md
+++ b/readme.md
@@ -144,14 +144,15 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 <br>
 
 ### 🛠️ **Options**
-```ts
+```js
 ViteWebfontDownload(
- [
-  'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
- ],
- {
-  async: false
- }
+  [
+    'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
+  ],
+  {
+	injectAsStyleTag: true,
+    async: true
+  }
 )
 ```
 
@@ -159,13 +160,16 @@ ViteWebfontDownload(
 
 ```js
 ViteWebfontDownload(
- {
-  async: false
- }
+  [],
+  {
+	injectAsStyleTag: true,
+    async: true
+  }
 )
 ```
 
-**`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues
+**`injectAsStyleTag`**: inject webfonts as `<style>` tag or as an external `.css` file
+**`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues (has no effect when `injectAsStyleTag` is `true`)
 
 ## 📚 Resources
 * [Page Speed Checklist / Fix & Eliminate Render Blocking Resources](https://pagespeedchecklist.com/eliminate-render-blocking-resources)

--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,12 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 <br>
 
 ### 🛠️ **Options**
+**`injectAsStyleTag`**: inject webfonts as `<style>` tag (embedded CSS) or as an external `.css` file
+
+**`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues (has no effect when `injectAsStyleTag` is `true`)
+
+*usage:*
+
 ```js
 ViteWebfontDownload(
   [
@@ -182,12 +188,12 @@ ViteWebfontDownload(
 )
 ```
 
-**`injectAsStyleTag`**: inject webfonts as `<style>` tag (embedded CSS) or as an external `.css` file
-**`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues (has no effect when `injectAsStyleTag` is `true`)
+<br>
 
 ## 📚 Resources
 * [Page Speed Checklist / Fix & Eliminate Render Blocking Resources](https://pagespeedchecklist.com/eliminate-render-blocking-resources)
 
+<br>
 
 ## 📄 License
 

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
   ...
 </style>
 ```
-**or**
+**or** *(using dev server or `injectAsStyleTag: false` option)*
 
 ```html
 <link rel="preload" as="style" href="/assets/webfonts.b904bd45.css">
@@ -148,7 +148,7 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 
 📱 What happens on client-side with **Webfont-DL plugin**:
 
-1. Load fonts from the `inline style tag`.
+1. Load fonts from the embedded CSS (`<style>` tag).
 
 **or**
 

--- a/readme.md
+++ b/readme.md
@@ -166,9 +166,7 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 
 ```js
 ViteWebfontDownload(
-  [
-    'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
-  ],
+  [],
   {
     injectAsStyleTag: true,
     async: true
@@ -176,11 +174,13 @@ ViteWebfontDownload(
 )
 ```
 
-**or**
+*or:*
 
 ```js
 ViteWebfontDownload(
-  [],
+  [
+    'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
+  ],
   {
     injectAsStyleTag: true,
     async: true

--- a/readme.md
+++ b/readme.md
@@ -4,19 +4,13 @@
 [![NPM downloads](https://img.shields.io/npm/dt/vite-plugin-webfont-dl)](https://www.npmjs.com/package/vite-plugin-webfont-dl)
 
 
-### **Make your Vite site load faster & boost SEO performance 🚀**
-
-⚠️ Using the standard method to add Google Fonts into a webpage can **slow down page load significantly.** **Lighthouse** and **PageSpeed Insights** audit calls this a **<i>"render-blocking resource"</i>**, which means that the page can't load until the font has been fetched from the Google Fonts server.
+⚠️ Using the standard method to add webfonts (like Google Fonts) to a webpage can **slow down page load significantly.** **Lighthouse** and **PageSpeed Insights** audit calls this a ***"render-blocking resource"***, which means that the page can't load until the font has been fetched from the Google Fonts server.
 
 📈 By avoiding render-blocking resources caused by Google Fonts loading, you can **boost page performance** which leads to **better user-experience** and **improves SEO results**. 🔎
 
-<br>
+⚙️ The plugin **downloads the given fonts from Google Fonts and dynamically injects** them *(internal or external CSS)* into your Vite project.
 
-### **Eliminate Render-Blocking Resources caused by Google Fonts 🔝**
-
-**💡 Webfont-DL plugin let's you leverage the flexibility of Google Fonts without trade-offs when it comes to page perfomance.**
-
-⚙️ The plugin **downloads the given fonts from Google Fonts and dynamically injects** them into your Vite project.
+💡 **Webfont-DL plugin** let's you leverage the flexibility of Google Fonts without trade-offs when it comes to page perfomance.
 
 <br>
 
@@ -31,7 +25,7 @@ npm i vite-plugin-webfont-dl -D
 
 *Extracts, downloads and injects fonts from the **original Google Fonts code snippet**.*
 
-0. Select your font families at [Google Fonts](https://fonts.google.com) and copy the code into `<head>` from the **<i>"Use on the web"</i>** block:
+0. Select your font families at [Google Fonts](https://fonts.google.com) and copy the code into `<head>` from the ***"Use on the web"*** block:
 	```html
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -56,7 +50,7 @@ npm i vite-plugin-webfont-dl -D
 
 *Extracts, downloads and injects fonts from the **configured webfont CSS URL(s)**.*
 
-0. Select your font families at [Google Fonts](https://fonts.google.com) and copy the **CSS URL**(s) from the **<i>"Use on the web"</i>** code block:
+0. Select your font families at [Google Fonts](https://fonts.google.com) and copy the **CSS URL**(s) from the ***"Use on the web"*** code block:
 	```html
 	<link href="[CSS URL]" rel="stylesheet">
 	```
@@ -108,7 +102,7 @@ h2 {
 
 ### **Google Fonts** 📉
 
-**Google Fonts** generates the following code which you have to inject into your website's `<head>` <i>(example)</i>:
+**Google Fonts** generates the following code which you have to inject into your website's `<head>`, *example*:
 
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -117,9 +111,9 @@ h2 {
 ```
 
 📱 What happens on client-side with **Google Fonts**:
-1. First line gives a hint to the browser to begin the connection handshake <i>(DNS, TCP, TLS)</i> with `fonts.googleapis.com`. This happens in the background to improve performance. [**`preconnect`**]
+1. First line gives a hint to the browser to begin the connection handshake *(DNS, TCP, TLS)* with `fonts.googleapis.com`. This happens in the background to improve performance. [**`preconnect`**]
 1. Second line is another preconnect hint to `fonts.gstatic.com`. [**`preconnect`**]
-1. Third line instructs the browser to load and use a CSS stylesheet file from `fonts.googleapis.com` <i>(with [`font-display:swap`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values))</i>. [**`stylesheet`**]
+1. Third line instructs the browser to load and use a CSS stylesheet file from `fonts.googleapis.com` *(with [`font-display:swap`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values))*. [**`stylesheet`**]
 1. The browser downloads the CSS file and starts to parse it. The parsed CSS is a set of `@font-face` definitions containing font URLs from `fonts.gstatic.com` server.
 1. The browser starts to download the all relevant fonts from `fonts.gstatic.com`.
 1. After the successful fonts download the browser swaps the fallback fonts to the downloaded ones.
@@ -130,19 +124,19 @@ h2 {
 
 On the contrary, **Webfont-DL plugin** does most of the job at build time, leaves the minimum to the browser.
 
-**Webfont-DL plugin** downloads the Google Fonts CSS file(s), extracts the font URLs, downloads the fonts, generates an inline style tag **or** a webfont CSS file, add them to the bundle and injects the following code into your website's `<head>` using a non-render blocking method <i>(example)</i>:
+**Webfont-DL plugin** downloads the Google Fonts CSS file(s), extracts the font URLs, downloads the fonts, generates an embedded CSS (`<style>` tag) **or** a webfont / external CSS file, add them to the bundle and injects the following code into your website's `<head>` using a non-render blocking method, *example*:
 
 ```html
 <style>
-	@font-face {
-		font-family: 'Fira Code';
-		font-style: normal;
-		font-weight: 300;
-		font-display: swap;
-		src: url(/assets/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_GNsJV37Nv7g.9c348768.woff2) format('woff2');
-		unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-	}
-	...
+  @font-face {
+    font-family: 'Fira Code';
+    font-style: normal;
+    font-weight: 300;
+    font-display: swap;
+    src: url(/assets/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_GNsJV37Nv7g.9c348768.woff2) format('woff2');
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  }
+  ...
 </style>
 ```
 **or**
@@ -159,7 +153,7 @@ On the contrary, **Webfont-DL plugin** does most of the job at build time, leave
 **or**
 
 1. First line instructs the browser to prefetch a CSS file for later use as stylesheet. [**`preload`**]
-1. Second line instructs the browser to load and use that CSS file as a "`print`" stylesheet <i>(non-render blocking)</i>. After loading it promote to "`all`" media type stylesheet (by removing the "`media`" attribute). [**`stylesheet`**]
+1. Second line instructs the browser to load and use that CSS file as a "`print`" stylesheet *(non-render blocking)*. After loading it promote to "`all`" media type stylesheet (by removing the "`media`" attribute). [**`stylesheet`**]
 
 <br>
 
@@ -170,7 +164,7 @@ ViteWebfontDownload(
     'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap'
   ],
   {
-	injectAsStyleTag: true,
+    injectAsStyleTag: true,
     async: true
   }
 )
@@ -182,13 +176,13 @@ ViteWebfontDownload(
 ViteWebfontDownload(
   [],
   {
-	injectAsStyleTag: true,
+    injectAsStyleTag: true,
     async: true
   }
 )
 ```
 
-**`injectAsStyleTag`**: inject webfonts as `<style>` tag or as an external `.css` file
+**`injectAsStyleTag`**: inject webfonts as `<style>` tag (embedded CSS) or as an external `.css` file
 **`async`**: prevent the usage of inline event handlers that can cause Content Security Policy issues (has no effect when `injectAsStyleTag` is `true`)
 
 ## 📚 Resources

--- a/src/css-injector.ts
+++ b/src/css-injector.ts
@@ -2,14 +2,21 @@ import { Options } from './types';
 
 export class CssInjector {
 
-	constructor(private options: Options) {}
+	constructor(private options: Options) { }
 
-	public inject(html: string, base: string, path: string): string {
+	public injectAsStylesheet(html: string, base: string, path: string): string {
 		if (this.options.async) {
 			return this.injectAsync(html, base, path);
 		} else {
 			return this.injectSync(html, base, path);
 		}
+	}
+
+	public injectAsStyleTag(html: string, cssContent: string): string {
+		return html.replace(
+			/([ \t]*)<\/head>/,
+			`$1<style>${cssContent}</style>\n</head>`
+		);
 	}
 
 

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -1,7 +1,7 @@
 import type { Options } from './types';
 
 const defaultOptions: Options = {
-	injectToHead: true,
+	injectAsStyleTag: true,
 	async: true,
 }
 

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -1,6 +1,7 @@
 import type { Options } from './types';
 
 const defaultOptions: Options = {
+	injectToHead: true,
 	async: true,
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export function ViteWebfontDownload(
 	};
 
 	const injectToHtml = (html: string, cssContent: string, base: string, cssPath: string): string => {
-		if (options.injectAsStyleTag === false) {
+		if (viteDevServer || options.injectAsStyleTag === false) {
 			return cssInjector.injectAsStylesheet(html, base, cssPath);
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export function ViteWebfontDownload(
 		_webfontUrls = [];
 	}
 
-	if (typeof _webfontUrls === 'string') {
+	if (typeof _webfontUrls === 'string' && _webfontUrls !== '') {
 		_webfontUrls = [_webfontUrls];
 	}
 
@@ -95,7 +95,7 @@ export function ViteWebfontDownload(
 	};
 
 	const injectToHtml = (html: string, cssContent: string, base: string, cssPath: string): string => {
-		if (options.injectToHead === false) {
+		if (options.injectAsStyleTag === false) {
 			return cssInjector.injectAsStylesheet(html, base, cssPath);
 		}
 
@@ -188,7 +188,7 @@ export function ViteWebfontDownload(
 				await downloadFonts();
 				replaceFontUrls();
 
-				if (options.injectToHead === false) {
+				if (options.injectAsStyleTag === false) {
 					saveCss();
 				}
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,12 +159,10 @@ export function ViteWebfontDownload(
 
 					const url = req.originalUrl as string;
 
-					// /assets/webfonts.css
-					if (url === base + cssPath) {
+					if (url === base + cssPath) { // /assets/webfonts.css
 						res.end(cssContent);
 
-						// /assets/xxx.woff2
-					} else if (fontUrls.has(url)) {
+					} else if (fontUrls.has(url)) { // /assets/xxx.woff2
 						res.end(await fontLoader.load(fontUrls.get(url) as string));
 
 					} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ServerResponse } from 'http';
-import type { ViteDevServer, Connect, ResolvedConfig, Plugin, HtmlTagDescriptor } from 'vite';
+import type { ViteDevServer, Connect, ResolvedConfig, Plugin } from 'vite';
 import { PluginContext } from 'rollup';
 import type { Font, Options } from './types';
 import { CssLoader } from './css-loader';
@@ -184,19 +184,14 @@ export function ViteWebfontDownload(
 				}
 			}
 
-			if (options?.injectToHead) {
-				const tag: HtmlTagDescriptor[] = [
-					{
-						tag: 'style',
-						children: cssContent,
-					}
-				]
+			html = indexHtmlProcessor.removeTags(html);
 
-				return tag;
+			if (options?.injectToHead) {
+				html = cssInjector.injectAsStyleTag(html, cssContent);
+			} else {
+				html = cssInjector.injectAsStylesheet(html, base, cssPath);
 			}
 
-			html = indexHtmlProcessor.removeTags(html);
-			html = cssInjector.inject(html, base, cssPath);
 
 			return html;
 		},

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,13 +7,13 @@ export interface Font {
  * This is the description of the interface
  *
  * @interface Options
- * @member {boolean} async is used to import stylesheet asynchronously.
  * @member {boolean} injectToHead is used to inject critical css between style tag.
+ * @member {boolean} async is used to import stylesheet asynchronously.
  */
 export interface Options {
-	/** Import stylesheet asynchronously. Has no effect when ```injectToHead``` is true */
-	async?: boolean;
 	/** Inject critical css between style tag */
 	injectToHead?: boolean;
+	/** Import stylesheet asynchronously. Has no effect when `injectToHead` is true */
+	async?: boolean;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,7 +3,15 @@ export interface Font {
 	localPath: string;
 }
 
+/**
+ * This is the description of the interface
+ *
+ * @interface Options
+ * @member {boolean} injectToHead is used to inject critical css between style tag
+ */
 export interface Options {
 	async?: boolean;
+	/** Inject critical css between style tag */
+	injectToHead?: boolean;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,9 +7,11 @@ export interface Font {
  * This is the description of the interface
  *
  * @interface Options
- * @member {boolean} injectToHead is used to inject critical css between style tag
+ * @member {boolean} async is used to import stylesheet asynchronously.
+ * @member {boolean} injectToHead is used to inject critical css between style tag.
  */
 export interface Options {
+	/** Import stylesheet asynchronously. Has no effect when ```injectToHead``` is true */
 	async?: boolean;
 	/** Inject critical css between style tag */
 	injectToHead?: boolean;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,13 +7,13 @@ export interface Font {
  * This is the description of the interface
  *
  * @interface Options
- * @member {boolean} injectToHead is used to inject critical css between style tag.
+ * @member {boolean} injectAsStyleTag is used to inject critical css between style tag.
  * @member {boolean} async is used to import stylesheet asynchronously.
  */
 export interface Options {
 	/** Inject critical css between style tag */
-	injectToHead?: boolean;
-	/** Import stylesheet asynchronously. Has no effect when `injectToHead` is true */
+	injectAsStyleTag?: boolean;
+	/** Import stylesheet asynchronously. Has no effect when `injectAsStyleTag` is `true` */
 	async?: boolean;
 }
 


### PR DESCRIPTION
- Inject generated css between a `<style>` tag in the `<head>` instead of generating into a separated css file. This approach is not count as render-blocking resource so it's as fast as the async version. This method also fix SSR manifest issue (https://github.com/feat-agency/vite-plugin-webfont-dl/issues/9).

- This will be the default option but you can turn it off if you want use the async method instead:
```js
ViteWebfontDownload([],
 {
  injectAsStyleTag: false
 }
)
```