### PR TITLE
fix: missing file extension in downloaded font

### DIFF
--- a/src/css-parser.ts
+++ b/src/css-parser.ts
@@ -46,10 +46,11 @@ export class CssParser {
 				const filename = url.match(this.googleFontsFileRegex)?.[1]?.toString();
 
 				if (filename) {
-					fonts.set(filename + '.woff2', {
+					const filenameWithExtension = filename + '.woff2';
+					fonts.set(filenameWithExtension, {
 						url,
-						filename,
-						localPath: base + (assetsDir ? assetsDir + '/' : '') + filename + '.woff2',
+						filename: filenameWithExtension,
+						localPath: base + (assetsDir ? assetsDir + '/' : '') + filenameWithExtension,
 					});
 				}
 			}


### PR DESCRIPTION
The downloaded font is sometimes saved without extension to the file system.

```
webfontDownload([
  'https://fonts.googleapis.com/css2?family=Roboto:wght@700&display=swap&text=Sign in with Google',
]),
```