### PR TITLE
Migrate to flat-cache v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,11 @@
 			"dependencies": {
 				"axios": "^1",
 				"clean-css": "^5",
-				"flat-cache": "^5",
+				"flat-cache": "^6",
 				"picocolors": "^1"
 			},
 			"devDependencies": {
 				"@types/clean-css": "^4",
-				"@types/flat-cache": "^2",
 				"@types/node": "^22",
 				"@typescript-eslint/eslint-plugin": "^8",
 				"eslint": "^9",
@@ -667,6 +666,15 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@keyv/serialize": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.1.tgz",
+			"integrity": "sha512-kKXeynfORDGPUEEl2PvTExM2zs+IldC6ZD8jPcfvI351MDNtfMlw9V9s4XZXuJNDK2qR5gbEKxRyoYx3quHUVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^6.0.3"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -918,12 +926,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
-		},
-		"node_modules/@types/flat-cache": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@types/flat-cache/-/flat-cache-2.0.2.tgz",
-			"integrity": "sha512-uZRK+n0d9JBzcEqjRJGD9SiPtDKUn4E5w4n6iFHqAdgylJFc2Eh2KK9UimvH/saz6dwGC36Jt1DzyKBvHiEIgA==",
-			"dev": true
 		},
 		"node_modules/@types/node": {
 			"version": "22.2.0",
@@ -1323,6 +1325,26 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1356,6 +1378,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
 		"node_modules/bundle-require": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.0.0.tgz",
@@ -1378,6 +1424,25 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/cacheable": {
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.4.tgz",
+			"integrity": "sha512-eqcPwJIM8hcx2mQIZtgrBQ7BmOf2pkL+1URswJaKRikCDw5of/lGpBTxODL1z1VuVVuxZHTuTejAMd9vyAUpLg==",
+			"license": "MIT",
+			"dependencies": {
+				"hookified": "^1.5.0",
+				"keyv": "^5.2.1"
+			}
+		},
+		"node_modules/cacheable/node_modules/keyv": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.1.tgz",
+			"integrity": "sha512-tpIgCaY02VCW2Pz0zAn4guyct+IeH6Mb5wZdOvpe4oqXeQOJO0C3Wo8fTnf7P3ZD83Vr9kghbkNmzG3lTOhy/A==",
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "*"
 			}
 		},
 		"node_modules/callsites": {
@@ -1992,15 +2057,14 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-			"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.2.tgz",
+			"integrity": "sha512-WakhGOkx886u7DJGpgMpUU81VUYHyQlXuqPDI53g6lIVHf7Shepr/XGo7Qa0yYOPwyMItQs34dG7X0KgnHwWtQ==",
+			"license": "MIT",
 			"dependencies": {
+				"cacheable": "^1.8.1",
 				"flatted": "^3.3.1",
-				"keyv": "^4.5.4"
-			},
-			"engines": {
-				"node": ">=18"
+				"hookified": "^1.4.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -2181,6 +2245,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/hookified": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.5.0.tgz",
+			"integrity": "sha512-4U0zw2ibOws7kfGdNCIL6oRg+t6ITxkgi9kUaJ71IDp0ZATHjvY6o7l90RBa/R8H2qOKl47SZISA5a3hNnei1g==",
+			"license": "MIT"
+		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2189,6 +2259,26 @@
 			"engines": {
 				"node": ">=10.17.0"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -2341,7 +2431,8 @@
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -2359,6 +2450,7 @@
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"axios": "^1",
 		"clean-css": "^5",
-		"flat-cache": "^5",
+		"flat-cache": "^6",
 		"picocolors": "^1"
 	},
 	"peerDependencies": {
@@ -50,7 +50,6 @@
 	},
 	"devDependencies": {
 		"@types/clean-css": "^4",
-		"@types/flat-cache": "^2",
 		"@types/node": "^22",
 		"@typescript-eslint/eslint-plugin": "^8",
 		"eslint": "^9",


### PR DESCRIPTION
The flat-cache package has a new major release v6; see also https://github.com/jaredwray/cacheable/tree/main/packages/flat-cache#breaking-changes-from-v5-to-v6.

This PR aims to update to the new major version and migrate the code to be compatible.

This fixes an issue when using this package with Yarn (PnP mode), which would yield an error message `[webfont-dl] EROFS: read-only filesystem, mkdir '/node_modules/flat-cache/.cache'` when building with default settings. This is due to the fact that Yarn does not allow writes on packages (see https://yarnpkg.com/blog/release/2.0#read-only-packages). The new version of flat-cache writes to `.cache` at the project root by default, which is safer.