### PR TITLE
Add option to throw errors rather than catching them

### DIFF
--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -8,6 +8,7 @@ const defaultOptions: Required<Options> = {
 	cache: true,
 	proxy: false,
 	assetsSubfolder: '',
+	throwError: false,
 };
 
 export const getResolvedOptions = (options: Options = {}): Required<Options> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -439,15 +439,20 @@ function viteWebfontDownload(
 					});
 				}
 			} catch (error) {
-				logger.error(
-					colors.red((error as Error).message)
-				);
+				if (options.throwError) {
+					throw error;
+				} else {
+					// Log error only so that Vite build can continue to succeed.
+					logger.error(
+						colors.red((error as Error).message)
+					);
 
-				if (error instanceof AxiosError) {
-					if (error.request instanceof ClientRequest) {
-						logger.error(
-							colors.red(`${error.request.method} ${error.request.protocol}//${error.request.host}${error.request.path}`)
-						);
+					if (error instanceof AxiosError) {
+						if (error.request instanceof ClientRequest) {
+							logger.error(
+								colors.red(`${error.request.method} ${error.request.protocol}//${error.request.host}${error.request.path}`)
+							);
+						}
 					}
 				}
 			}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -62,5 +62,10 @@ export interface Options {
 	 * default: `''`
 	 */
 	assetsSubfolder?: string;
-}
 
+	/**
+	 * Throw on error to make Vite build fail.
+	 * default: `false`
+	 */
+	throwError?: boolean;
+}


### PR DESCRIPTION
This MR adds a `throwError` option, that when enabled throws errors rather than catching them and turning them in log messages. When errors are thrown, this will make the Vite build job fail, which can be useful for situations where one considers succesful downloading and bundling of webfonts essential, e.g. CI builds.

The option defaults to `false` to ensure behavior for existing installations remains the same.

Fixes #63