### PR TITLE
Retain same manifest outputted names with Vite v6

### DIFF
--- a/src/webfont-download.ts
+++ b/src/webfont-download.ts
@@ -293,6 +293,7 @@ export class WebfontDownload {
 	saveFile(fileName: string, source: string | Buffer): string {
 		const ref = this.emitFile({
 			name: fileName,
+			originalFileName: fileName,
 			type: 'asset',
 			source: source,
 		});


### PR DESCRIPTION
Fixes #65

By setting `originalFileName` on `emitFile` calls, the output I produced with my Laravel MWE (https://github.com/jnoordsij/laravel-laravel/compare/webfont-dl-mwe) is identical with Vite v5 and Vite v6. This is inspired by https://github.com/vitejs/vite/pull/18820, where Vite "internally" does the same thing to mark the asset as "implicit entrypoint".

It seems somewhat odd when comparing to the notes Rollup docs provide on this (see https://rollupjs.org/plugin-development/#this-emitfile), but doesn't seem harmful from what I can see.

