### PR TITLE
Fix percentage display for 0 total operations

### DIFF
--- a/src/webfont-download.ts
+++ b/src/webfont-download.ts
@@ -198,10 +198,14 @@ export class WebfontDownload {
 				colors.green('✓') + ' ' +
 				allWebfontUrls.size.toString() + ' webfont css downloaded. ' +
 				colors.dim('(' +
-					colors.bold(this.toDuration(started)) + ', ' +
-					(this.options.cache !== false ?
-						`cache hit: ${colors.bold(this.toPercent(this.fileCache.hits.css, allWebfontUrls.size))}` :
-						'cache disabled'
+					colors.bold(this.toDuration(started)) +
+					(allWebfontUrls.size ? (
+						', ' + (
+							this.options.cache !== false ?
+								`cache hit: ${colors.bold(this.toPercent(this.fileCache.hits.css, allWebfontUrls.size))}` :
+								'cache disabled'
+							)
+						) : ''
 					) +
 				')'),
 				false
@@ -247,9 +251,13 @@ export class WebfontDownload {
 			this.fonts.size + ' webfonts downloaded. ' +
 			colors.dim('(' +
 				colors.bold(this.toDuration(started)) + ', ' +
-				(this.options.cache !== false ?
-					`cache hit: ${colors.bold(this.toPercent(this.fileCache.hits.font, this.fonts.size))}` :
-					'cache disabled'
+				(this.fonts.size ? (
+					', ' +
+						(this.options.cache !== false ?
+							`cache hit: ${colors.bold(this.toPercent(this.fileCache.hits.font, this.fonts.size))}` :
+							'cache disabled'
+						)
+					) : ''
 				) +
 			')'),
 			false

--- a/src/webfont-download.ts
+++ b/src/webfont-download.ts
@@ -392,6 +392,10 @@ export class WebfontDownload {
 	}
 
 	private toPercent(value: number, total: number): string {
-		return (Math.round(value / total * 100 * 100) / 100).toFixed(2) + '%';
+		const percent = total > 0
+			? (Math.round(value / total * 100 * 100) / 100).toFixed(2)
+			: '100';
+
+		return `${percent}%`;
 	}
 }

--- a/src/webfont-download.ts
+++ b/src/webfont-download.ts
@@ -392,10 +392,6 @@ export class WebfontDownload {
 	}
 
 	private toPercent(value: number, total: number): string {
-		const percent = total > 0
-			? (Math.round(value / total * 100 * 100) / 100).toFixed(2)
-			: '100';
-
-		return `${percent}%`;
+		return (Math.round(value / total * 100 * 100) / 100).toFixed(2) + '%';
 	}
 }


### PR DESCRIPTION
When you have 0 webfonts references in a Vite build, the current output will be:
```
✓ 0 webfont css downloaded. (0 ms, cache hit: NaN%)
```

Given that `NaN%` looks a bit confusing, probably 100% is a neater alternative.